### PR TITLE
chore: update Go version to 1.25

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Go ${{ matrix.go-version }}
+      - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: '1.25'
 
       - name: Package version
         id: package_version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.24' ]
+        go-version: [ '1.25' ]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Talk-Point/go-toolkit
 
-go 1.24.1
+go 1.25


### PR DESCRIPTION
## Summary
- Updated `go.mod` from Go 1.24.1 to Go 1.25
- Updated CI workflow Go version from 1.24 to 1.25
- Fixed CD workflow to use explicit Go 1.25 version (was using undefined matrix variable)

## Related Issue
Relates to Talk-Point/IT#13762

## Test plan
- [ ] CI pipeline runs successfully with Go 1.25
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)