### PR TITLE
chore: update Go version to 1.25 (complete)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.25' ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.24' ]
+        go-version: [ '1.25' ]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Talk-Point/go-toolkit
 
-go 1.24.1
+go 1.25


### PR DESCRIPTION
## Summary
- Update go.mod from Go 1.24.1 to 1.25
- Update ci.yml matrix from 1.24 to 1.25
- Add missing matrix strategy to cd.yml with go-version 1.25

## Files Changed
- `go.mod`
- `.github/workflows/ci.yml`
- `.github/workflows/cd.yml`

## Related Issue
Fixes https://github.com/Talk-Point/IT/issues/13762