### PR TITLE
fix: downgrade go version from 1.25 to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Talk-Point/go-toolkit
 
-go 1.25
+go 1.24


### PR DESCRIPTION
## Summary
- Go 1.25 does not exist yet
- This breaks dependent projects (go-webtoolkit) running Go 1.24.x in CI

## Test plan
- CI should pass with Go 1.24

🤖 Generated with [Claude Code](https://claude.com/claude-code)